### PR TITLE
feat: add paginated EPIC gallery

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -6,10 +6,12 @@ Seris uses a small set of external HTTP endpoints:
 
 * `GET https://api.jikan.moe/v4/random/anime`
 * `GET https://api.jikan.moe/v4/random/manga`
+* `GET https://api.nasa.gov/EPIC/api/natural/images?api_key=...`
 * `GET https://api.nasa.gov/planetary/apod?api_key=...`
 
 ## Notes
 
 * Jikan is used for `/anime random` and `/manga random`.
+* EPIC is used for `/epic`.
 * NASA APOD is used for `/nasa apod`.
 * Seris does not expose internal HTTP endpoints.

--- a/src/commands/epic.rs
+++ b/src/commands/epic.rs
@@ -1,0 +1,74 @@
+use log::{error, info};
+use poise::CreateReply;
+
+use crate::embeds;
+use crate::epic::EpicSession;
+use crate::services::epic::get_epic_images;
+use crate::types::{Context, Error};
+
+/// Replies with paginated EPIC Earth imagery.
+#[poise::command(
+    slash_command,
+    description_localized("pt-BR", "Mostra imagens EPIC da Terra com botões")
+)]
+pub async fn epic(
+    ctx: Context<'_>,
+    #[choices("natural", "enhanced")]
+    #[description = "Tipo de imagem EPIC"]
+    kind: &'static str,
+    #[description = "Data YYYY-MM-DD (opcional)"] date: Option<String>,
+) -> Result<(), Error> {
+    ctx.data()
+        .database
+        .record_command_usage_best_effort(ctx.author().id, "epic");
+
+    let normalized_date = match date {
+        Some(date) => {
+            if chrono::NaiveDate::parse_from_str(&date, "%Y-%m-%d").is_err() {
+                ctx.say("D-desculpe... a data precisa estar no formato YYYY-MM-DD.")
+                    .await?;
+                return Ok(());
+            }
+
+            Some(date)
+        }
+        None => None,
+    };
+
+    ctx.defer().await?;
+
+    let nasa_api_key = ctx.data().config.nasa_api_key.clone();
+    let images = get_epic_images(nasa_api_key, kind, normalized_date.as_deref()).await;
+
+    let images = match images {
+        Ok(images) if !images.is_empty() => images,
+        Ok(_) => {
+            ctx.say("E-eu não encontrei imagens EPIC para essa data.")
+                .await?;
+            return Ok(());
+        }
+        Err(err) => {
+            error!("failed to fetch EPIC images: {err}");
+            ctx.say("D-desculpe... tente novamente mais tarde.").await?;
+            return Ok(());
+        }
+    };
+
+    info!("EPIC returned {} images for {}", images.len(), kind);
+
+    let session = EpicSession::new(ctx.author().id, kind.to_string(), images);
+    let reply = CreateReply::default()
+        .embed(embeds::epic::epic(
+            session.current_image(),
+            session.current_index(),
+            session.total_pages(),
+            session.kind(),
+        ))
+        .components(session.components());
+
+    let handle = ctx.send(reply).await?;
+    let message = handle.message().await?;
+    ctx.data().epic_sessions.insert(message.id.get(), session);
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,6 +6,7 @@ use poise::Command;
 
 pub mod anime;
 pub mod clear;
+pub mod epic;
 pub mod manga;
 pub mod nasa;
 pub mod ping;
@@ -30,6 +31,7 @@ mod tests {
             vec![
                 "ping",
                 "clear",
+                "epic",
                 "apod",
                 "get_random_anime",
                 "get_random_manga",

--- a/src/commands/utility.rs
+++ b/src/commands/utility.rs
@@ -14,7 +14,7 @@ pub async fn about(ctx: Context<'_>) -> Result<(), Error> {
 
     let version = env!("CARGO_PKG_VERSION");
     let message = format!(
-        "S-sou a Seris v{version}\nConheço estes comandos: ping, clear, apod, anime, manga, about, uptime, stats"
+        "S-sou a Seris v{version}\nConheço estes comandos: ping, clear, epic, apod, anime, manga, about, uptime, stats"
     );
 
     ctx.say(message).await?;

--- a/src/embeds/epic.rs
+++ b/src/embeds/epic.rs
@@ -1,0 +1,47 @@
+use serenity::{all::CreateEmbed, builder::CreateEmbedFooter, model::colour};
+
+use crate::services::epic::EpicImage;
+
+/// Builds an EPIC image embed.
+pub fn epic(image: &EpicImage, page: usize, total: usize, kind: &str) -> CreateEmbed {
+    CreateEmbed::new()
+        .title(format!("EPIC {kind}"))
+        .url(image.url.clone())
+        .description(image.caption.clone())
+        .image(image.url.clone())
+        .footer(CreateEmbedFooter::new(format!(
+            "Página {}/{} • {} • {}",
+            page + 1,
+            total,
+            image.short_date(),
+            image.image
+        )))
+        .color(colour::Colour::from_rgb(47, 106, 217))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::epic;
+    use crate::services::epic::EpicImage;
+
+    #[test]
+    fn epic_sets_expected_fields() {
+        let embed = epic(
+            &EpicImage {
+                image: "epic_1b_20260409011359".to_string(),
+                caption: "Earth".to_string(),
+                date: "2026-04-09 01:13:59".to_string(),
+                url: "https://example.com/epic.png".to_string(),
+            },
+            0,
+            3,
+            "natural",
+        );
+
+        let value = serde_json::to_value(embed).expect("embed serializes");
+
+        assert_eq!(value["title"], "EPIC natural");
+        assert_eq!(value["description"], "Earth");
+        assert_eq!(value["image"]["url"], "https://example.com/epic.png");
+    }
+}

--- a/src/embeds/mod.rs
+++ b/src/embeds/mod.rs
@@ -1,5 +1,6 @@
 //! Embed builders for Discord responses.
 
 pub mod anime;
+pub mod epic;
 pub mod manga;
 pub mod nasa;

--- a/src/epic.rs
+++ b/src/epic.rs
@@ -1,0 +1,270 @@
+//! Shared EPIC session state and component handling.
+
+use poise::{serenity_prelude as serenity, BoxFuture};
+use serenity::{
+    all::{ButtonStyle, ComponentInteraction, FullEvent, Interaction, UserId},
+    builder::{
+        CreateActionRow, CreateButton, CreateEmbed, CreateInteractionResponse,
+        CreateInteractionResponseMessage,
+    },
+};
+
+use crate::{
+    embeds,
+    services::epic::EpicImage,
+    types::{Data, Error},
+};
+
+const ACTION_PREFIX: &str = "epic:";
+
+/// A live EPIC gallery session tied to a single Discord message.
+#[derive(Clone, Debug)]
+pub struct EpicSession {
+    owner_id: UserId,
+    kind: String,
+    images: Vec<EpicImage>,
+    current_index: usize,
+}
+
+impl EpicSession {
+    /// Creates a new gallery session.
+    pub fn new(owner_id: UserId, kind: String, images: Vec<EpicImage>) -> Self {
+        Self {
+            owner_id,
+            kind,
+            images,
+            current_index: 0,
+        }
+    }
+
+    /// Returns the current image.
+    pub fn current_image(&self) -> &EpicImage {
+        &self.images[self.current_index]
+    }
+
+    /// Returns the current zero-based page index.
+    pub fn current_index(&self) -> usize {
+        self.current_index
+    }
+
+    /// Returns the total number of pages.
+    pub fn total_pages(&self) -> usize {
+        self.images.len()
+    }
+
+    /// Returns the active kind label.
+    pub fn kind(&self) -> &str {
+        &self.kind
+    }
+
+    /// Builds the message components for the current page.
+    pub fn components(&self) -> Vec<CreateActionRow> {
+        let is_first = self.current_index == 0;
+        let is_last = self.current_index + 1 >= self.images.len();
+
+        vec![CreateActionRow::Buttons(vec![
+            CreateButton::new(format!("{ACTION_PREFIX}first"))
+                .label("Primeira")
+                .style(ButtonStyle::Secondary)
+                .disabled(is_first),
+            CreateButton::new(format!("{ACTION_PREFIX}prev"))
+                .label("Anterior")
+                .style(ButtonStyle::Secondary)
+                .disabled(is_first),
+            CreateButton::new(format!("{ACTION_PREFIX}next"))
+                .label("Próxima")
+                .style(ButtonStyle::Secondary)
+                .disabled(is_last),
+            CreateButton::new(format!("{ACTION_PREFIX}last"))
+                .label("Última")
+                .style(ButtonStyle::Secondary)
+                .disabled(is_last),
+        ])]
+    }
+
+    /// Builds the current embed.
+    pub fn embed(&self) -> CreateEmbed {
+        embeds::epic::epic(
+            self.current_image(),
+            self.current_index,
+            self.images.len(),
+            &self.kind,
+        )
+    }
+
+    /// Applies a navigation action to the session.
+    pub fn navigate(&mut self, action: EpicAction) {
+        match action {
+            EpicAction::First => self.current_index = 0,
+            EpicAction::Prev => {
+                self.current_index = self.current_index.saturating_sub(1);
+            }
+            EpicAction::Next => {
+                self.current_index =
+                    (self.current_index + 1).min(self.images.len().saturating_sub(1));
+            }
+            EpicAction::Last => {
+                self.current_index = self.images.len().saturating_sub(1);
+            }
+        }
+    }
+}
+
+/// EPIC navigation actions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EpicAction {
+    /// Jump to the first page.
+    First,
+    /// Go back one page.
+    Prev,
+    /// Advance one page.
+    Next,
+    /// Jump to the final page.
+    Last,
+}
+
+fn parse_action(custom_id: &str) -> Option<EpicAction> {
+    match custom_id.strip_prefix(ACTION_PREFIX)? {
+        "first" => Some(EpicAction::First),
+        "prev" => Some(EpicAction::Prev),
+        "next" => Some(EpicAction::Next),
+        "last" => Some(EpicAction::Last),
+        _ => None,
+    }
+}
+
+async fn handle_component_interaction(
+    ctx: &serenity::Context,
+    data: &Data,
+    interaction: &ComponentInteraction,
+) -> Result<(), Error> {
+    let Some(action) = parse_action(&interaction.data.custom_id) else {
+        return Ok(());
+    };
+
+    let message_id = interaction.message.id.get();
+    enum Reject {
+        Missing,
+        Forbidden,
+    }
+
+    let render = match data.epic_sessions.get_mut(&message_id) {
+        None => Err(Reject::Missing),
+        Some(mut session) => {
+            if session.owner_id != interaction.user.id {
+                Err(Reject::Forbidden)
+            } else {
+                session.navigate(action);
+                Ok((session.embed(), session.components()))
+            }
+        }
+    };
+
+    let (embed, components) = match render {
+        Ok(render) => render,
+        Err(Reject::Missing) => {
+            interaction
+                .create_response(
+                    ctx,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("E-eu perdi essa galeria... tente abrir o comando de novo.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await?;
+            return Ok(());
+        }
+        Err(Reject::Forbidden) => {
+            interaction
+                .create_response(
+                    ctx,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content("D-desculpe... só quem abriu o comando pode navegar.")
+                            .ephemeral(true),
+                    ),
+                )
+                .await?;
+            return Ok(());
+        }
+    };
+
+    interaction
+        .create_response(
+            ctx,
+            CreateInteractionResponse::UpdateMessage(
+                CreateInteractionResponseMessage::new()
+                    .embeds(vec![embed])
+                    .components(components),
+            ),
+        )
+        .await?;
+
+    Ok(())
+}
+
+/// Framework event handler that routes EPIC button clicks.
+pub fn framework_event_handler<'a>(
+    ctx: &'a serenity::Context,
+    event: &'a FullEvent,
+    _framework: poise::FrameworkContext<'a, Data, Error>,
+    data: &'a Data,
+) -> BoxFuture<'a, Result<(), Error>> {
+    Box::pin(async move {
+        if let FullEvent::InteractionCreate {
+            interaction: Interaction::Component(interaction),
+        } = event
+        {
+            handle_component_interaction(ctx, data, interaction).await?;
+        }
+
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_action, EpicAction, EpicSession};
+    use crate::services::epic::EpicImage;
+    use serenity::all::UserId;
+
+    #[test]
+    fn parses_actions() {
+        assert_eq!(parse_action("epic:first"), Some(EpicAction::First));
+        assert_eq!(parse_action("epic:prev"), Some(EpicAction::Prev));
+        assert_eq!(parse_action("epic:next"), Some(EpicAction::Next));
+        assert_eq!(parse_action("epic:last"), Some(EpicAction::Last));
+        assert_eq!(parse_action("noop"), None);
+    }
+
+    #[test]
+    fn navigates_pages() {
+        let mut session = EpicSession::new(
+            UserId::new(1),
+            "natural".to_string(),
+            vec![
+                EpicImage {
+                    image: "1".to_string(),
+                    caption: "one".to_string(),
+                    date: "2026-04-09 00:00:00".to_string(),
+                    url: "https://example.com/1".to_string(),
+                },
+                EpicImage {
+                    image: "2".to_string(),
+                    caption: "two".to_string(),
+                    date: "2026-04-09 00:00:01".to_string(),
+                    url: "https://example.com/2".to_string(),
+                },
+            ],
+        );
+
+        assert_eq!(session.current_index(), 0);
+        session.navigate(EpicAction::Next);
+        assert_eq!(session.current_index(), 1);
+        session.navigate(EpicAction::Prev);
+        assert_eq!(session.current_index(), 0);
+        session.navigate(EpicAction::Last);
+        assert_eq!(session.current_index(), 1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ pub mod database;
 #[cfg(feature = "bot")]
 pub mod embeds;
 #[cfg(feature = "bot")]
+pub mod epic;
+#[cfg(feature = "bot")]
 pub mod plugins;
 #[cfg(feature = "bot")]
 pub mod services;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use dashmap::DashMap;
 use env_logger::Env;
 use log::{error, info, warn};
 use seris::cli::{parse, Command as CliCommand};
@@ -81,10 +82,12 @@ async fn run() -> Result<(), Error> {
     let database = Arc::new(Database::open_default()?);
     info!("database ready");
     let started_at = Instant::now();
+    let epic_sessions = Arc::new(DashMap::new());
 
     let framework = poise::Framework::builder()
         .options(poise::FrameworkOptions {
             commands: commands(),
+            event_handler: seris::epic::framework_event_handler,
             ..Default::default()
         })
         .setup(move |ctx, _ready, framework| {
@@ -93,6 +96,7 @@ async fn run() -> Result<(), Error> {
                 Ok(Data {
                     config,
                     database: Arc::clone(&database),
+                    epic_sessions: Arc::clone(&epic_sessions),
                     started_at,
                 })
             })

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -1,7 +1,7 @@
 //! Lightweight internal plugin registry for command groups.
 
 use crate::{
-    commands::{anime, clear, manga, nasa, ping, utility},
+    commands::{anime, clear, epic, manga, nasa, ping, utility},
     types::{Data, Error},
 };
 use poise::Command;
@@ -72,7 +72,7 @@ impl Plugin for ContentPlugin {
     }
 
     fn commands(&self) -> Vec<Command<Data, Error>> {
-        vec![nasa::apod(), anime::random(), manga::random()]
+        vec![epic::epic(), nasa::apod(), anime::random(), manga::random()]
     }
 }
 

--- a/src/services/epic.rs
+++ b/src/services/epic.rs
@@ -1,0 +1,188 @@
+//! NASA EPIC API helpers and response models.
+
+use std::sync::OnceLock;
+
+use reqwest::Url;
+use serde::Deserialize;
+
+use super::http;
+use crate::types::Error;
+
+const API_URL: &str = "https://api.nasa.gov/EPIC";
+const SERVICE_NAME: &str = "nasa-epic";
+
+fn api_url() -> &'static Url {
+    static URL: OnceLock<Url> = OnceLock::new();
+    URL.get_or_init(|| Url::parse(API_URL).expect("valid EPIC url"))
+}
+
+/// EPIC image metadata returned by NASA.
+#[derive(Clone, Deserialize, Debug)]
+struct EpicImageMetadata {
+    /// Image identifier.
+    pub image: String,
+    /// Image caption.
+    pub caption: String,
+    /// Timestamp string returned by the API.
+    pub date: String,
+}
+
+/// Resolved EPIC image used by the bot.
+#[derive(Clone, Debug)]
+pub struct EpicImage {
+    /// Image identifier.
+    pub image: String,
+    /// Image caption.
+    pub caption: String,
+    /// Timestamp string returned by the API.
+    pub date: String,
+    /// Resolved archive image URL.
+    pub url: String,
+}
+
+impl EpicImage {
+    /// Returns the date portion used for display.
+    pub fn short_date(&self) -> &str {
+        self.date.split_whitespace().next().unwrap_or(&self.date)
+    }
+}
+
+fn archive_url(kind: &str, date: &str, image: &str, api_key: &str) -> String {
+    let day = date.split_whitespace().next().unwrap_or(date);
+    let mut parts = day.split('-');
+    let year = parts.next().unwrap_or("0000");
+    let month = parts.next().unwrap_or("00");
+    let day = parts.next().unwrap_or("00");
+
+    format!(
+        "https://api.nasa.gov/EPIC/archive/{kind}/{year}/{month}/{day}/png/{image}.png?api_key={api_key}"
+    )
+}
+
+fn endpoint(kind: &str, date: Option<&str>) -> String {
+    let base = api_url().as_str().trim_end_matches('/');
+
+    match date {
+        Some(date) => format!("{base}/api/{kind}/date/{date}"),
+        None => format!("{base}/api/{kind}/images"),
+    }
+}
+
+/// Fetches EPIC images from a specific base URL.
+pub async fn get_epic_images_from(
+    base_url: &str,
+    api_key: String,
+    kind: &str,
+    date: Option<&str>,
+) -> Result<Vec<EpicImage>, Error> {
+    let base = base_url.trim_end_matches('/');
+    let endpoint = match date {
+        Some(date) => format!("{base}/api/{kind}/date/{date}"),
+        None => format!("{base}/api/{kind}/images"),
+    };
+    let query_key = api_key.clone();
+    let archive_key = api_key;
+    let kind = kind.to_string();
+
+    let metadata: Vec<EpicImageMetadata> = http::get_json(SERVICE_NAME, move || {
+        http::client()
+            .get(&endpoint)
+            .query(&[("api_key", query_key.clone())])
+    })
+    .await?;
+
+    Ok(metadata
+        .into_iter()
+        .map(|item| EpicImage {
+            url: archive_url(&kind, &item.date, &item.image, &archive_key),
+            image: item.image,
+            caption: item.caption,
+            date: item.date,
+        })
+        .collect())
+}
+
+/// Fetches EPIC images from NASA.
+pub async fn get_epic_images(
+    api_key: String,
+    kind: &str,
+    date: Option<&str>,
+) -> Result<Vec<EpicImage>, Error> {
+    let endpoint = endpoint(kind, date);
+    let query_key = api_key.clone();
+    let archive_key = api_key;
+    let kind = kind.to_string();
+
+    let metadata: Vec<EpicImageMetadata> = http::get_json(SERVICE_NAME, move || {
+        http::client()
+            .get(&endpoint)
+            .query(&[("api_key", query_key.clone())])
+    })
+    .await?;
+
+    Ok(metadata
+        .into_iter()
+        .map(|item| EpicImage {
+            url: archive_url(&kind, &item.date, &item.image, &archive_key),
+            image: item.image,
+            caption: item.caption,
+            date: item.date,
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{archive_url, get_epic_images_from, EpicImage};
+    use crate::test_utils::spawn_json_server;
+
+    #[tokio::test]
+    async fn parses_epic_response() {
+        let server = spawn_json_server(
+            r#"[{"image":"epic_1b_20260409011359","caption":"Earth","date":"2026-04-09 01:13:59"}]"#,
+        )
+        .await;
+
+        let response = get_epic_images_from(&server.url, "abc123".to_string(), "natural", None)
+            .await
+            .expect("epic response");
+
+        assert_eq!(response.len(), 1);
+        assert_eq!(response[0].image, "epic_1b_20260409011359");
+        assert_eq!(response[0].caption, "Earth");
+        assert_eq!(response[0].short_date(), "2026-04-09");
+        assert_eq!(
+            response[0].url,
+            "https://api.nasa.gov/EPIC/archive/natural/2026/04/09/png/epic_1b_20260409011359.png?api_key=abc123"
+        );
+        assert_eq!(
+            server.request_line().await.as_deref(),
+            Some("GET /api/natural/images?api_key=abc123 HTTP/1.1")
+        );
+    }
+
+    #[test]
+    fn builds_archive_url() {
+        assert_eq!(
+            archive_url(
+                "enhanced",
+                "2026-04-09 01:13:59",
+                "epic_1b_20260409011359",
+                "abc123"
+            ),
+            "https://api.nasa.gov/EPIC/archive/enhanced/2026/04/09/png/epic_1b_20260409011359.png?api_key=abc123"
+        );
+    }
+
+    #[test]
+    fn epic_image_short_date_uses_day_prefix() {
+        let image = EpicImage {
+            image: "epic".to_string(),
+            caption: "Earth".to_string(),
+            date: "2026-04-09 01:13:59".to_string(),
+            url: "https://example.com".to_string(),
+        };
+
+        assert_eq!(image.short_date(), "2026-04-09");
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,5 +1,6 @@
 //! External service clients and response types.
 
+pub mod epic;
 pub(crate) mod http;
 pub mod jikan;
 pub mod nasa;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,7 @@
 //! Shared application state and error types.
 
 use crate::config::AppConfig;
+use dashmap::DashMap;
 use reqwest::StatusCode;
 use std::sync::Arc;
 use std::time::Instant;
@@ -79,6 +80,8 @@ pub struct Data {
     pub config: AppConfig,
     /// SQLite-backed persistence.
     pub database: Arc<crate::database::Database>,
+    /// Active EPIC gallery sessions keyed by Discord message id.
+    pub epic_sessions: Arc<DashMap<u64, crate::epic::EpicSession>>,
     /// When the process started.
     pub started_at: Instant,
 }

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -9,6 +9,7 @@ fn registers_expected_commands() {
         vec![
             "ping",
             "clear",
+            "epic",
             "apod",
             "get_random_anime",
             "get_random_manga",

--- a/tests/services.rs
+++ b/tests/services.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use common::spawn_json_server;
+use seris::services::epic::get_epic_images_from;
 use seris::services::jikan::{get_random_anime_from, get_random_manga_from};
 use seris::services::nasa::get_astronomy_picture_day_from;
 
@@ -72,6 +73,31 @@ async fn fetches_apod_from_mock_server() {
     assert_eq!(
         server.request_line().await.as_deref(),
         Some("GET /?api_key=abc123 HTTP/1.1")
+    );
+}
+
+#[tokio::test]
+async fn fetches_epic_from_mock_server() {
+    let server = spawn_json_server(
+        r#"[{"image":"epic_1b_20260409011359","caption":"Earth","date":"2026-04-09 01:13:59"}]"#,
+    )
+    .await;
+
+    let response = get_epic_images_from(&server.url, "abc123".to_string(), "natural", None)
+        .await
+        .expect("epic response");
+
+    assert_eq!(response.len(), 1);
+    assert_eq!(response[0].image, "epic_1b_20260409011359");
+    assert_eq!(response[0].caption, "Earth");
+    assert_eq!(response[0].short_date(), "2026-04-09");
+    assert_eq!(
+        response[0].url,
+        "https://api.nasa.gov/EPIC/archive/natural/2026/04/09/png/epic_1b_20260409011359.png?api_key=abc123"
+    );
+    assert_eq!(
+        server.request_line().await.as_deref(),
+        Some("GET /api/natural/images?api_key=abc123 HTTP/1.1")
     );
 }
 


### PR DESCRIPTION
## Summary
- Add a new `/epic` command that fetches NASA EPIC Earth images.
- Paginate images with navigation buttons for first/prev/next/last.
- Keep the gallery tied to the user who opened it.

## Validation
- `cargo fmt --all`
- `cargo test --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`